### PR TITLE
Fix QNAN converting to IND

### DIFF
--- a/smallfolk.lua
+++ b/smallfolk.lua
@@ -51,7 +51,11 @@ function dump_object(object, nmemo, memo, acc)
 	elseif object == nil then
 		acc[#acc + 1] = 'n'
 	elseif object ~= object then
-		acc[#acc + 1] = 'N'
+		if (''..object):sub(1,1) == '-' then
+			acc[#acc + 1] = 'N'
+		else
+			acc[#acc + 1] = 'Q'
+		end
 	elseif object == huge then
 		acc[#acc + 1] = 'I'
 	elseif object == -huge then
@@ -130,6 +134,7 @@ local expect_object_head = {
 	t = function(string, i) return true, i end,
 	f = function(string, i) return false, i end,
 	n = function(string, i) return nil, i end,
+	Q = function(string, i) return -(0/0), i end,
 	N = function(string, i) return 0/0, i end,
 	I = function(string, i) return 1/0, i end,
 	i = function(string, i) return -1/0, i end,


### PR DESCRIPTION
Fixes:

``` lua
local tbl = {1/0, 0/0, -(1/0), -(0/0), math.huge, -math.huge}
local data = smallfolk.loads(smallfolk.dumps(tbl))
print(table.unpack(data))
print(table.unpack(tbl))

-- output:
1.#INF  -1.#IND -1.#INF -1.#IND 1.#INF  -1.#INF
1.#INF  -1.#IND -1.#INF 1.#QNAN 1.#INF  -1.#INF
```

Btw. Nice serializer :+1: 
Faster than anything I see, as fast for serializing and deserializing, light and most importantly secure.
Additional bonus is that your code produces strikingly short output to go along with my needs for serializing client-server messages.
